### PR TITLE
Removed call to private API for recursive description of views and repla...

### DIFF
--- a/DCIntrospect-ARC/DCIntrospect.m
+++ b/DCIntrospect-ARC/DCIntrospect.m
@@ -301,10 +301,9 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 
 - (void)invokeIntrospector
 {
-	self.on = !self.on;
-	
-	if (self.on)
+	if (!self.on)
 	{
+        self.on = YES;
 		[self updateViews];
 		[self updateStatusBar];
 		[self updateFrameView];
@@ -332,6 +331,8 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 		self.frameView.alpha = 0;
 		self.currentView = nil;
 		
+        self.on = NO;
+        
 		[[NSNotificationCenter defaultCenter] postNotificationName:kDCIntrospectNotificationIntrospectionDidEnd
 															object:nil];
 	}


### PR DESCRIPTION
Removed call to private API for recursive description of views and replaced with custom implementation. Replaced DEBUG check in the sharedIntrospector with a check for TARGET_IPHONE_SIMULATOR. Then it is no longer necessary to include this check when starting the introspector.

Furthermore this removes all checks for DEBUG which causes problems for some CocoaPods configurations in which DEBUG is not always defined. I have not been able to find out why this is. However I think this commit is an improvement because DCIntrospect now will be available in the simulator in all build configurations.
