### PR TITLE
Fixed criticial issue causing DCIntrospect-ARC to launch on device

### DIFF
--- a/DCIntrospect-ARC/DCIntrospect.m
+++ b/DCIntrospect-ARC/DCIntrospect.m
@@ -175,7 +175,7 @@ id UITextInputTraits_valueForKey(id self, SEL _cmd, NSString *key)
 + (DCIntrospect *)sharedIntrospector
 {
 	static DCIntrospect *sharedInstance = nil;
-#ifdef TARGET_IPHONE_SIMULATOR
+#if TARGET_IPHONE_SIMULATOR
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
 		sharedInstance = [[DCIntrospect alloc] init];


### PR DESCRIPTION
If the start command isn't wrapped in a #if DEBUG, DCIntrospect-ARC could launch on device because TARGET_IPHONE_SIMULATOR is defined on devices, but set to 0 and the code checked if the macro was defined, not its value. Please review this fix thoroughly.
