### PR TITLE
Show view controller if available

### DIFF
--- a/DCIntrospect-ARC/DCIntrospect.m
+++ b/DCIntrospect-ARC/DCIntrospect.m
@@ -582,7 +582,15 @@ static bool AmIBeingDebugged(void)
 
 - (NSString *)nameForObject:(id)object
 {
-	__block NSString *objectName = [NSString stringWithFormat:@"%@", [object class]];
+	id vc = nil;
+	NSString *viewControllerKey = @"_viewDelegate";
+	if ([object respondsToSelector:NSSelectorFromString(viewControllerKey)]) {
+		vc = [object valueForKey:viewControllerKey];
+	}
+
+	__block NSString *objectName = vc ? [NSString stringWithFormat:@"%@ (%@)", [object class], [vc class]] :
+			[NSString stringWithFormat:@"%@", [object class]];
+
 	if (!self.objectNames)
 		return objectName;
 	


### PR DESCRIPTION
Shows the the name of the associated viewcontroller to the selected view if available (See screenshot). It makes it easy to find the correct viewcontroller when debugging an app with many viewcontrollers.

![](https://cloud.githubusercontent.com/assets/390601/5569759/6635c0e4-8f76-11e4-855d-e3e1a82287ae.png)
