### PR TITLE
Fixed DC stealing first responder from textfield on iOS9

### DIFF
--- a/DCIntrospect-ARC/DCIntrospect.m
+++ b/DCIntrospect-ARC/DCIntrospect.m
@@ -159,13 +159,15 @@ static bool AmIBeingDebugged(void)
 	
 	// reclaim the keyboard after dismissal if it is taken
 	[[NSNotificationCenter defaultCenter] addObserverForName:UIKeyboardDidHideNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
-		self.keyboardVisible = NO;
-		
-		// needs to be done after a delay or else it doesn't work for some reason.
-		if (self.keyboardBindingsOn)
-			[self performSelector:@selector(takeFirstResponder)
-					   withObject:nil
-					   afterDelay:0.1];
+        if (self.keyboardVisible) {
+            self.keyboardVisible = NO;
+            
+            // needs to be done after a delay or else it doesn't work for some reason.
+            if (self.keyboardBindingsOn)
+                [self performSelector:@selector(takeFirstResponder)
+                           withObject:nil
+                           afterDelay:0.1];
+        }
 	}];
     
     // dirty hack for UIWebView keyboard problems


### PR DESCRIPTION
On iOS9 the notification `UIKeyboardDidHideNotification` is posted when a textfield is selected and hardware keyboard is selected. This is not the case on iOS8. This change in behaviour triggers DC to take the first responder when a textfield is selected (while having hardware keyboard enabled). I added a check to determine if the `UIKeyboardDidShowNotification` notification has been posted, which fixes the problem.