### PR TITLE
Add <UIKit/UIKit.h> import

### DIFF
--- a/DCIntrospect-ARC/DCIntrospect.h
+++ b/DCIntrospect-ARC/DCIntrospect.h
@@ -8,6 +8,7 @@
 #define kDCIntrospectNotificationIntrospectionDidEnd @"kDCIntrospectNotificationIntrospectionDidEnd"
 #define kDCIntrospectAnimationDuration 0.08
 
+#import <UIKit/UIKit.h>
 #import <objc/runtime.h>
 #include "TargetConditionals.h"
 


### PR DESCRIPTION
For projects that don't have `<UIKit/UIKit.h>` in their precompiled header, this is required to fix build errors. This seems reasonable for a project that includes many `UIView` subclasses.

<img width="300" alt="screenshot 2016-02-03 13 54 19" src="https://cloud.githubusercontent.com/assets/48065/12798330/a56d9726-ca7d-11e5-9b74-54dcd6fb3764.png">

<img width="822" alt="screenshot 2016-02-03 13 54 56" src="https://cloud.githubusercontent.com/assets/48065/12798343/bdcd6396-ca7d-11e5-8268-b9ef9db2c54f.png">
